### PR TITLE
Add Game Runtime and SFSE version checks

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -232,6 +232,12 @@ globals:
 
 # Latest Version
   # Starfield Game Runtime
+#  - <<: *versionOldX
+#    subs: [ '**Starfield**' ]
+#    condition: 'readable("../Starfield.exe") and product_version("../Starfield.exe", "1.7.23.0", >=) and product_version("../Starfield.exe", "1.7.23.0", <)'
+  - <<: *versionUpToDateX
+    subs: [ '**Starfield**' ]
+    condition: 'readable("../Starfield.exe") and product_version("../Starfield.exe", "1.7.23.0", >=)'
 
 groups:
   - name: &mainGroup Main Plugins

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -238,6 +238,14 @@ globals:
   - <<: *versionUpToDateX
     subs: [ '**Starfield**' ]
     condition: 'readable("../Starfield.exe") and product_version("../Starfield.exe", "1.7.23.0", >=)'
+  # SFSE
+  # https://github.com/ianpatt/sfse
+#  - <<: *versionOldX
+#    subs: [ '**[SFSE](https://www.nexusmods.com/starfield/mods/106/)**' ]
+#    condition: 'file("../sfse_loader.exe") and version("../sfse_loader.exe", "0.0.1.0", <) and readable("../Starfield.exe") and product_version("../Starfield.exe", "1.7.23.0", >=)'
+  - <<: *versionUpToDateX
+    subs: [ '**SFSE**' ]
+    condition: 'version("../sfse_loader.exe", "0.0.1.0", >=) and readable("../Starfield.exe") and product_version("../Starfield.exe", "1.7.23.0", >=)'
 
 groups:
   - name: &mainGroup Main Plugins


### PR DESCRIPTION
- `versionOldX` messages currently commented out, as these versions are the first public releases
- The first `product_version()` that checks for `>=` within the `versionOldX` message is used for the "old" version. Currently there is only one version of `Starfield.exe` as such, right now both `product_version()` check the same version number.
- `conditions` can and should be expanded, if GOG and/or EGS releases are getting shipped