### PR TITLE
Remove global warning message

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -235,15 +235,6 @@ globals:
 # Latest LOOT Thread
   - *latestLOOTThread
 
-# Warn users of plugins that were made before the CK was released
-# Temporary warning - Pending removal once CK is released
-  - type: warn
-    content:
-      - lang: en
-        text: 'It is recommended not to use mods that contain **plugins** (i.e. files ending in **.esm**, **.esp** or **.esl**), until official modding tools have been made available.'
-      - lang: bg
-        text: 'Препоръчва се все още да не използвате модификации, които съдържат **приставки** (**.esm**, **.esp** или **.esl** файлове).'
-
 # Latest Version
   # Starfield Game Runtime
   - <<: *versionOldX


### PR DESCRIPTION
xEdit 4.1.5 (and as such SF1Edit) has been released, and the number of plugins created with it increases each day.
While xEdit is not the CK, I'd say it's okay to remove the general & global message, that warns people to not use es[mpl] mods. 