### PR TITLE
Update Game Runtime (1.11.36.0) and SFSE (0.0.2.7) version checks

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -247,17 +247,17 @@ globals:
   # Starfield Game Runtime
   - <<: *versionOldX
     subs: [ '**Starfield**' ]
-    condition: 'readable("../Starfield.exe") and product_version("../Starfield.exe", "1.9.67.0", <)'
+    condition: 'readable("../Starfield.exe") and product_version("../Starfield.exe", "1.11.36.0", <)'
   - <<: *versionUpToDateX
     subs: [ '**Starfield**' ]
-    condition: 'readable("../Starfield.exe") and product_version("../Starfield.exe", "1.9.67.0", >=)'
+    condition: 'readable("../Starfield.exe") and product_version("../Starfield.exe", "1.11.36.0", >=)'
   # SFSE
   - <<: *versionOldX
     subs: [ '**[SFSE](https://www.nexusmods.com/starfield/mods/106/)**' ]
-    condition: 'file("../sfse_loader.exe") and version("../sfse_loader.exe", "0.0.2.3", <) and readable("../Starfield.exe") and product_version("../Starfield.exe", "1.9.67.0", >=)'
+    condition: 'file("../sfse_loader.exe") and version("../sfse_1_11_36.dll", "0.0.2.7", <) and readable("../Starfield.exe") and product_version("../Starfield.exe", "1.11.36.0", >=)'
   - <<: *versionUpToDateX
     subs: [ '**SFSE**' ]
-    condition: 'version("../sfse_loader.exe", "0.0.2.3", >=) and readable("../Starfield.exe") and product_version("../Starfield.exe", "1.9.67.0", >=)'
+    condition: 'version("../sfse_1_11_36.dll", "0.0.2.7", >=) and readable("../Starfield.exe") and product_version("../Starfield.exe", "1.11.36.0", >=)'
 
 # SFSE
   # Missing


### PR DESCRIPTION
[SFSE - Nexus](https://www.nexusmods.com/starfield/mods/106/)

We no longer can check the version of `sfse_loader.exe` in order to check if the latest version of SFSE is used, because since version `0.2.6` of SFSE
> the loader has been made version-independent due to continued problems with false positives

As such, check the version of the bundled `sfse_x_x_x.dll` e.g.

`version("../sfse_1_11_36.dll", "0.0.2.7", <)`