### PR TITLE
Add &filenameExtension warning for esp and esl plugins

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -244,14 +244,14 @@ common:
 bash_tags: []
 
 globals:
-# File extension .esp
+# Filename extension .esp
   - <<: *filenameExtension
     subs:
       - 'Starfield'
       - '.esp'
     condition: 'file("([^\.]+\.esp)")'
 
-# File extension .esl
+# Filename extension .esl
   - <<: *filenameExtension
     subs:
       - 'Starfield'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -212,6 +212,10 @@ prelude:
 
   # Cleaning Data Anchors
   # Global Anchors
+    - &filenameExtension
+      type: error
+      content: '{0} does not support the usage of **{1}** plugins ingame, but your load order contains such plugins. In order to avoid irreversible damage to your game, it is recommended to not use **{1}** plugins.'
+
     - &incompatible
       type: error
       content: '{0} is incompatible with {1}, but both are present.'
@@ -240,6 +244,20 @@ common:
 bash_tags: []
 
 globals:
+# File extension .esp
+  - <<: *filenameExtension
+    subs:
+      - 'Starfield'
+      - '.esp'
+    condition: 'file("([^\.]+\.esp)")'
+
+# File extension .esl
+  - <<: *filenameExtension
+    subs:
+      - 'Starfield'
+      - '.esl'
+    condition: 'file("([^\.]+\.esl)")'
+
 # Latest LOOT Thread
   - *latestLOOTThread
 


### PR DESCRIPTION
This PR adds the `masterlist` side of https://github.com/loot/loot/issues/1989#issuecomment-2171087549

In addition to warning about `.esp` plugins, also warn about `.esl` plugins.