### PR TITLE
Mention &unsupportedChangeVerified in prelude node

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -164,7 +164,7 @@ prelude:
       content: 'You seem to be using **{0}**, but it has been superseded. It is recommended that you use **{1}** instead.'
 
     - &unsupportedChangeVerified
-      type: say
+      type: warn
       content: 'This plugin has been changed from **{0}** to **{1}**.'
       subs: [ '' ]
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -163,6 +163,11 @@ prelude:
       type: warn
       content: 'You seem to be using **{0}**, but it has been superseded. It is recommended that you use **{1}** instead.'
 
+    - &unsupportedChangeVerified
+      type: say
+      content: 'This plugin has been changed from **{0}** to **{1}**.'
+      subs: [ '' ]
+
     - &useBashTweakInstead
       type: say
       content: 'A Bashed Patch tweak can be used instead of this plugin. {0}'


### PR DESCRIPTION
`Masterlist` side of https://github.com/loot/loot/issues/1989#issuecomment-2163913984

This message can be added to a plugin for example like this:

```yaml
  - name: 'Example.esm'
    msg:
      - <<: *unsupportedChangeVerified
        subs:
          - 'Full Master'
          - 'Medium Master'
        condition: 'checksum("Example.esm", 6FFE25B7)'
```