### PR TITLE
Add official BGS Creations

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -351,6 +351,31 @@ plugins:
     group: *mainGroup
 
 ###### Official BGS Creations ######
+  - name: 'sfbgs00a_a.esm'
+    url:
+      - link: 'https://creations.bethesda.net/en/starfield/details/31ccf130-4852-417b-842a-9d82672028e4/Skin__Blackout__Drum_Beat_/'
+        name: 'Blackout Drumbeat Skin (Bethesda.net Mods)'
+
+  - name: 'sfbgs00e.esm'
+    url:
+      - link: 'https://creations.bethesda.net/en/starfield/details/bdf19afb-2be7-43ad-b023-9c310e3602d9/Constellation_Plushie_Set/'
+        name: 'Constellation Plushie Set (Bethesda.net Mods)'
+
+  - name: 'sfbgs021.esm'
+    url:
+      - link: 'https://creations.bethesda.net/en/starfield/details/e8ff65fc-7c13-44b3-b8a5-27df6b28007d/Observatory/'
+        name: 'Observatory (Bethesda.net Mods)'
+
+  - name: 'sfbgs023.esm'
+    url:
+      - link: 'https://creations.bethesda.net/en/starfield/details/beefc7ae-59f4-4934-b2a5-d04e5264f029/Starborn_Gravis_Suit/'
+        name: 'Starborn Gravis Suit (Bethesda.net Mods)'
+
+  - name: 'sfta01.esm'
+    url:
+      - link: 'https://creations.bethesda.net/en/starfield/details/4bf1a31f-46d5-47bf-a5e6-d0f9e2496d0c/Trackers_Alliance__The_Vulture/'
+        name: 'Trackers Alliance: The Vulture (Bethesda.net Mods)'
+
 ###### Verified Creations ######
 ###### Base Game Patches ######
   - name: 'StarfieldCommunityPatch.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -350,6 +350,8 @@ plugins:
   - name: 'SFBGS008.esm'
     group: *mainGroup
 
+###### Official BGS Creations ######
+###### Verified Creations ######
 ###### Base Game Patches ######
   - name: 'StarfieldCommunityPatch.esm'
     url:


### PR DESCRIPTION
[Official BGS Creations](https://creations.bethesda.net/en/starfield/all?author_displayname=BethesdaGameStudios)

While we usually refrain from adding metadata only consisting out of `url`'s, in this case it's appropritiate since these creations are made by Bethesda Game Studios themselves - and the plugin names aren't exactly human-readable, so adding this location data that includes names should help.

There is currently one official BGS Creation missing from the list: [Ancient Mariner Module](https://creations.bethesda.net/en/starfield/details/07fe73ab-6edb-471d-8769-7bff25ffeb95/Ancient_Mariner_Module/)
I don't own this creation, so I don't know the plugin name. Through some google search I am suspecting the plugin name to be `sfbgs009.esm`, but this is only speculation. We would need this getting confirmed, before we can add this to the masterlist.

This PR also adds a new section for `Verified Creations` - in case some volunteers from the community provide us with the required information to add metadata for such plugins. The required information would be:
- the exact plugin name, e.g. `example.esm`
- the creations page where the plugin can be accessed from
- additional information would be welcome, e.g. if the plugin is a Full, Medium or Small Master