### PR TITLE
Mention &mismatchedFormIDs in prelude node

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -77,6 +77,10 @@ prelude:
       type: say
       content: 'The **{0}** master must be reassigned to **{1}**.'
 
+    - &mismatchedFormIDs
+      type: error
+      content: 'This plugin is a **{0}**, but it contains FormIDs that do not match this type of Master. Using this plugin would have unpredictable consequences for your game and is therefore not recommended.'
+
     - &missingRequirementXforY
       type: warn
       content: 'It appears you have installed **{1}**, but some of its requirements seem to be missing. Please ensure you have correctly installed **{0}**.'


### PR DESCRIPTION
`Masterlist` side of https://github.com/loot/loot/issues/1989#issuecomment-2185320379

This message can be added to a plugin for example like this:

```yaml
  - name: 'Example.esm'
    msg:
      - <<: *mismatchedFormIDs
        subs: [ 'Medium Master' ]
        condition: 'checksum("Example.esm", 6FFE25B7)'
```