### PR TITLE
Update BGS Creations

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -365,6 +365,11 @@ plugins:
       - link: 'https://creations.bethesda.net/en/starfield/details/bdf19afb-2be7-43ad-b023-9c310e3602d9/Constellation_Plushie_Set/'
         name: 'Constellation Plushie Set'
 
+  - name: 'sfbgs009.esm'
+    url:
+      - link: 'https://creations.bethesda.net/en/starfield/details/07fe73ab-6edb-471d-8769-7bff25ffeb95/Ancient_Mariner_Module/'
+        name: 'Ancient Mariner Module'
+
   - name: 'sfbgs021.esm'
     url:
       - link: 'https://creations.bethesda.net/en/starfield/details/e8ff65fc-7c13-44b3-b8a5-27df6b28007d/Observatory/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -358,27 +358,27 @@ plugins:
   - name: 'sfbgs00a_a.esm'
     url:
       - link: 'https://creations.bethesda.net/en/starfield/details/31ccf130-4852-417b-842a-9d82672028e4/Skin__Blackout__Drum_Beat_/'
-        name: 'Blackout Drumbeat Skin (Bethesda.net Mods)'
+        name: 'Blackout Drumbeat Skin'
 
   - name: 'sfbgs00e.esm'
     url:
       - link: 'https://creations.bethesda.net/en/starfield/details/bdf19afb-2be7-43ad-b023-9c310e3602d9/Constellation_Plushie_Set/'
-        name: 'Constellation Plushie Set (Bethesda.net Mods)'
+        name: 'Constellation Plushie Set'
 
   - name: 'sfbgs021.esm'
     url:
       - link: 'https://creations.bethesda.net/en/starfield/details/e8ff65fc-7c13-44b3-b8a5-27df6b28007d/Observatory/'
-        name: 'Observatory (Bethesda.net Mods)'
+        name: 'Observatory'
 
   - name: 'sfbgs023.esm'
     url:
       - link: 'https://creations.bethesda.net/en/starfield/details/beefc7ae-59f4-4934-b2a5-d04e5264f029/Starborn_Gravis_Suit/'
-        name: 'Starborn Gravis Suit (Bethesda.net Mods)'
+        name: 'Starborn Gravis Suit'
 
   - name: 'sfta01.esm'
     url:
       - link: 'https://creations.bethesda.net/en/starfield/details/4bf1a31f-46d5-47bf-a5e6-d0f9e2496d0c/Trackers_Alliance__The_Vulture/'
-        name: 'Trackers Alliance: The Vulture (Bethesda.net Mods)'
+        name: 'Trackers Alliance: The Vulture'
 
 ###### Verified Creations ######
 ###### Base Game Patches ######


### PR DESCRIPTION
Add location for `Ancient Mariner Module`.
Also shorten the location names, they only will be available from `bethesda.net` anyway.