### PR TITLE
Add RealisticDamageMultipliers.esm

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -517,6 +517,14 @@ plugins:
 
 ###### Gameplay - Character Classes & Races ######
 ###### Gameplay - Combat ######
+  - name: 'RealisticDamageMultipliers.esm'
+    url:
+      - link: 'https://www.nexusmods.com/starfield/mods/188/'
+        name: 'Realistic Damage Multipliers'
+    msg:
+      - <<: *corrupt
+        condition: 'checksum("RealisticDamageMultipliers.esm", CBC568FF)'
+
 ###### Gameplay - Crafting & Harvesting ######
   - name: 'legendaries.es[mp]'
     url:


### PR DESCRIPTION
Under https://github.com/loot/starfield/issues/8

- [Realistic Damage Multipliers](https://www.nexusmods.com/starfield/mods/188/)
- In `Gameplay - Combat` section
- Adds `corrupt` message
- Form version `552` instead of `575`
- From the modpage: `This version uses an experimental converted Fallout 4 plugin. You must follow the installation instructions on the main page. This version is not currently recommended.`