### PR TITLE
Add ShatteredSpace.esm

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -372,6 +372,12 @@ plugins:
     group: *mainGroup
 
 ###### Official DLC ######
+  - name: 'ShatteredSpace.esm'
+    url:
+      - link: 'https://creations.bethesda.net/en/starfield/details/b6b52ca2-3f1f-4316-bef8-dcb0bb2dcc32/Starfield__Shattered_Space/'
+        name: 'Starfield: Shattered Space'
+    group: *mainGroup
+
 ###### Official BGS Creations ######
   - name: 'sfbgs00a_a.esm'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -371,6 +371,7 @@ plugins:
   - name: 'SFBGS008.esm'
     group: *mainGroup
 
+###### Official DLC ######
 ###### Official BGS Creations ######
   - name: 'sfbgs00a_a.esm'
     url:


### PR DESCRIPTION
Under https://github.com/loot/loot/issues/2032

I've chosen to add a new category for Shattered Space:
`###### Official DLC ######`

It's treated as a base game file, however it's advertised as a [Creation](https://creations.bethesda.net/en/starfield/details/b6b52ca2-3f1f-4316-bef8-dcb0bb2dcc32/Starfield__Shattered_Space/).