### PR TITLE
fix regex plugin names

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -551,7 +551,7 @@ plugins:
 ###### Resources & Frameworks ######
 ###### AudioVisual ######
 ###### AudioVisual - Animations & Physics ######
-  - name: 'MoreDramaticGravJumps.es[mp]'
+  - name: 'MoreDramaticGravJumps\.es[mp]'
     url:
       - link: 'https://www.nexusmods.com/starfield/mods/2413/'
         name: 'More Dramatic Grav Jumps'
@@ -592,7 +592,7 @@ plugins:
         condition: 'checksum("RealisticDamageMultipliers.esm", CBC568FF)'
 
 ###### Gameplay - Crafting & Harvesting ######
-  - name: 'legendaries.es[mp]'
+  - name: 'legendaries\.es[mp]'
     url:
       - link: 'https://www.nexusmods.com/starfield/mods/1379/'
         name: 'Legendary Modifications'


### PR DESCRIPTION
As far as I understand yaml, loot and the masterlists for the other games, the period before the file extensions needs to be escaped, otherwise a regex like `MoreDramaticGravJumps.es[mp]` would not only match `MoreDramaticGravJumps.esm` and `MoreDramaticGravJumps.esp` but also stuff like `MoreDramaticGravJumpsAesp`, `MoreDramaticGravJumps/esp` or `MoreDramaticGravJumps-esp`, since unescaped `.` is a wildcard.