### PR TITLE
add The Final Patch (by KaeArby)

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -628,8 +628,6 @@ plugins:
 ###### 3RD Party Patches ######
 
 ###### Anything new can go after this (If you're not sure where to put it) ######
-
-###### Late Fixes & Changes ######
   - name: 'final patch.esm'
     url:
       - link: 'https://www.nexusmods.com/starfield/mods/12072/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -628,3 +628,12 @@ plugins:
 ###### 3RD Party Patches ######
 
 ###### Anything new can go after this (If you're not sure where to put it) ######
+
+###### Late Fixes & Changes ######
+  - name: 'final patch.esm'
+    url:
+      - link: 'https://www.nexusmods.com/starfield/mods/12072/'
+        name: 'The Final Patch (Nexus Mods)'
+      - link: 'https://creations.bethesda.net/en/starfield/details/04278b2d-3e4a-4b3c-8dee-0d98bab3ddad/The_Final_Patch/'
+        name: 'The Final Patch (Bethesda.net Mods)'
+    group: *lateChangesGroup


### PR DESCRIPTION
This change adds The Final Patch by KaeArby to the Late Changes & Fixes group so the ESM is added to the end of the plugin list.

From the mod author:

> Bethesda made to add the maps are in the plugin SFBGS008.esm and nobody, and I mean nobody, copies those changes forward when they edit the cell. This mod is simply copies of the cell records from SFBGS008.esm so you can place it near the bottom of your load order and get those surface maps back.