### PR TITLE
Update BGS creation: Trackers Alliance

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -510,11 +510,40 @@ plugins:
         name: 'Creature Plushie Set'
     group: *bgsCreationsGroup
 
-  - name: 'sfta01.esm'
+  - name: '(blueprintships-)?sfta0[1-6]\.esm'
     url:
-      - link: 'https://creations.bethesda.net/en/starfield/details/4bf1a31f-46d5-47bf-a5e6-d0f9e2496d0c/Trackers_Alliance__The_Vulture/'
-        name: 'Trackers Alliance: The Vulture'
+      - link: 'https://creations.bethesda.net/en/starfield/details/4bf1a31f-46d5-47bf-a5e6-d0f9e2496d0c/Trackers_Alliance__The_Complete_Bounty_Series'
+        name: 'Trackers Alliance: The Complete Bounty Series'
     group: *bgsCreationsGroup
+
+  - name: 'sfta02.esm'
+    after: [ 'sfta01.esm' ]
+
+  - name: 'sfta03.esm'
+    after:
+      - 'sfta01.esm'
+      - 'sfta02.esm'
+
+  - name: 'sfta04.esm'
+    after:
+      - 'sfta01.esm'
+      - 'sfta02.esm'
+      - 'sfta03.esm'
+
+  - name: 'sfta05.esm'
+    after:
+      - 'sfta01.esm'
+      - 'sfta02.esm'
+      - 'sfta03.esm'
+      - 'sfta04.esm'
+
+  - name: 'sfta06.esm'
+    after:
+      - 'sfta01.esm'
+      - 'sfta02.esm'
+      - 'sfta03.esm'
+      - 'sfta04.esm'
+      - 'sfta05.esm'
 
   - name: 'kgcdoom.esm'
     url:


### PR DESCRIPTION
Under https://github.com/loot/loot/issues/2180

- Update `url` and the associated `name`
- Add `after` rules for the new plugin entries `sfta02.esm` - `sfta06.esm`
  - List every previous entry for each plugin, so that the order prevails for every plugin in isolation
- Explicitly do not add `after` rules for the two new blueprint plugins `blueprintships-sfta03.esm` and `blueprintships-sfta06.esm`, because their order is not changed by `Plugins.txt` to begin with. LOOT itself needs to be updated for them.