### PR TITLE
Add sfbgs036.esm - Battle-Hardened Beowulf Skin

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -745,6 +745,34 @@ plugins:
       - 'sfbgs02a_a.esm'
       - 'sfbgs02b_a.esm'
 
+  - name: 'sfbgs036.esm'
+    url:
+      - link: 'https://creations.bethesda.net/en/starfield/details/739ff637-e4f7-4e4e-bc0b-c5e7795d10a5/Battle-Hardened_Beowulf_Skin/'
+        name: 'Battle-Hardened Beowulf Skin'
+    group: *bgsCreationsGroup
+    after:
+      - 'sfbgs009.esm'
+      - 'sfbgs00a_a.esm'
+      - 'sfbgs00a_d.esm'
+      - 'sfbgs00a_e.esm'
+      - 'sfbgs00a_f.esm'
+      - 'sfbgs00a_g.esm'
+      - 'sfbgs00a_i.esm'
+      - 'sfbgs00a_j.esm'
+      - 'sfbgs00b.esm'
+      - 'sfbgs00c.esm'
+      - 'sfbgs00e.esm'
+      - 'sfbgs00f_a.esm'
+      - 'sfbgs019.esm'
+      - 'sfbgs01b.esm'
+      - 'sfbgs01c.esm'
+      - 'sfbgs021.esm'
+      - 'sfbgs023.esm'
+      - 'sfbgs024.esm'
+      - 'sfbgs02a_a.esm'
+      - 'sfbgs02b_a.esm'
+      - 'sfbgs031.esm'
+
   - name: '(blueprintships-)?sfta0[1-6]\.esm'
     url:
       - link: 'https://creations.bethesda.net/en/starfield/details/4bf1a31f-46d5-47bf-a5e6-d0f9e2496d0c/Trackers_Alliance__The_Complete_Bounty_Series'


### PR DESCRIPTION
[Battle-Hardened Beowulf Skin](https://creations.bethesda.net/en/starfield/details/739ff637-e4f7-4e4e-bc0b-c5e7795d10a5/Battle-Hardened_Beowulf_Skin/) - `sfbgs036.esm`

<img width="2510" height="1245" alt="image1" src="https://github.com/user-attachments/assets/748a6a98-db0c-4ced-9f33-da11c09e09a5" />

Ref [Discord](https://discord.com/channels/473542112974077963/496196499890241546/1490442970371981313)
> hst2112 in #loot-discussions at 2026-04-05, 10:09 PM

<img width="764" height="1147" alt="image2" src="https://github.com/user-attachments/assets/ddcfe1b1-0e2b-45d6-94b5-ad3080420235" />

This official BGS creation can only be claimed by following the instructions on [freebundle.bethesda.net](https://freebundle.bethesda.net/en-US). It appears that the Steam account must be connected to Bethesda NET in order to be able to download this creation.

> *Promotion Window: This promotion begins on December 9, 2025 at 10AM ET, and ends on December 9, 2026 at 10AM ET.

Even if the ability to claim / download this BGS creation ends after `December 9, 2026` we should continue to list it within the masterlist.