### PR TITLE
Add Free Lanes and Terran Armada plugins

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -381,6 +381,10 @@ plugins:
     group: *mainGroup
   - name: 'SFBGS008.esm'
     group: *mainGroup
+  - name: 'SFBGS00D.esm'
+    group: *mainGroup
+  - name: 'SFBGS047.esm'
+    group: *mainGroup
 
 ###### Official DLC ######
   - name: 'ShatteredSpace.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -393,6 +393,18 @@ plugins:
         name: 'Starfield: Shattered Space'
     group: *mainGroup
 
+  - name: 'SFBGS050.esm'
+    url:
+      - link: 'https://store.steampowered.com/app/3763700/Starfield__Terran_Armada/'
+        name: 'Starfield - Terran Armada'
+    group: *mainGroup
+
+  - name: 'BlueprintShips-SFBGS050.esm'
+    url:
+      - link: 'https://store.steampowered.com/app/3763700/Starfield__Terran_Armada/'
+        name: 'Starfield - Terran Armada'
+    group: *mainGroup
+
 ###### Official BGS Creations ######
   - name: 'sfbgs009.esm'
     url:


### PR DESCRIPTION
[Bethesda.net](https://bethesda.net/en/game/starfield/article/7IxZSKYwYm1oDr57rXDx4C/starfield-free-lanes-terran-armada)

The `Terran Armada` DLC consists out of the two plugins `SFBGS050.esm` and `BlueprintShips-SFBGS050.esm`.
Explicitly do not write their entries as a regular expression.